### PR TITLE
Enable Firewall on Node, Add Windows Firewall rules for required ports

### DIFF
--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -201,8 +201,8 @@ Get-PodGateway(`$podCIDR)
 function
 Set-DockerNetwork(`$podCIDR)
 {    
-    # Allow all inbound traffic for TCP & UDP for all localports
-    # We do not want to block customer's container deployment port traffic by firewalling
+    # Allow all inbound traffic for TCP and UDP for all localports
+    # We do not want to block customer container deployment port traffic by firewalling
     netsh advfirewall firewall add rule name="Container: Allow all TCP inbound connections" dir=in action=allow protocol=TCP
     netsh advfirewall firewall add rule name="Container: Allow all UDP inbound connections" dir=in action=allow protocol=UDP
     

--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -200,12 +200,11 @@ Get-PodGateway(`$podCIDR)
 
 function
 Set-DockerNetwork(`$podCIDR)
-{
-    # Windows Firewall rules to allow only Master to access Node's kubelet ports
-    # Firewall rules to allow access to container's websockets
-    netsh advfirewall firewall add rule name="Container: Allow access to node localport 8080" dir=in action=allow protocol=TCP localport=8080
-    netsh advfirewall firewall add rule name="Container: Allow access to node localport 8888" dir=in action=allow protocol=TCP localport=8888
-    netsh advfirewall firewall add rule name="Container: Allow UDP inbound traffic for Container DNS Port 53" dir=in action=allow localport=53 protocol=UDP
+{    
+    # Allow all inbound traffic for TCP & UDP for all localports
+    # We do not want to block customer's container deployment port traffic by firewalling
+    netsh advfirewall firewall add rule name="Container: Allow all TCP inbound connections" dir=in action=allow protocol=TCP
+    netsh advfirewall firewall add rule name="Container: Allow all UDP inbound connections" dir=in action=allow protocol=UDP
     
     # 4194, 10250, 10255 are local kubelet ports used by Master to manage the nodes
     # We want only the Master to have access to these ports

--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -206,6 +206,9 @@ Set-DockerNetwork(`$podCIDR)
     netsh advfirewall firewall add rule name="Container: Allow access to node localport 8080" dir=in action=allow protocol=TCP localport=8080
     netsh advfirewall firewall add rule name="Container: Allow access to node localport 8888" dir=in action=allow protocol=TCP localport=8888
     netsh advfirewall firewall add rule name="Container: Allow UDP inbound traffic for Container DNS Port 53" dir=in action=allow localport=53 protocol=UDP
+    
+    # 4194, 10250, 10255 are local kubelet ports used by Master to manage the nodes
+    # We want only the Master to have access to these ports
     netsh advfirewall firewall add rule name="Node: Allow only K8 Master to access localport 4194" dir=in action=allow protocol=TCP localport=4194 remoteip=`${global:MasterIP}
     netsh advfirewall firewall add rule name="Node: Allow only K8 Master to access localport 10250" dir=in action=allow protocol=TCP localport=10250 remoteip=`${global:MasterIP}
     netsh advfirewall firewall add rule name="Node: Allow only K8 Master to access localport 10255" dir=in action=allow protocol=TCP localport=10255 remoteip=`${global:MasterIP}


### PR DESCRIPTION
**What this PR does / why we need it**:
Secures K8's Windows Nodes by enabling Firewall.
Allows only Master node to connect to kubelet ports
Creates Firewall exceptions for container websockets for communicating to PowerShell Console workloads

The fixes have been verified in DF cluster.

**Release note**:

```release-note
- Enable Firewall (with exceptions) for Windows Nodes to lockdown access to the nodes
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/725)
<!-- Reviewable:end -->
