### PR TITLE
 clear containers: update custom agent scripts

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -106,6 +106,7 @@ write_files:
     KUBELET_NETWORK_PLUGIN=kubenet
     KUBELET_MAX_PODS=110
     DOCKER_OPTS=
+    KUBELET_OPTS=
     CUSTOM_CMD=/bin/true
     KUBELET_REGISTER_SCHEDULABLE=true
     KUBELET_NODE_LABELS={{ GetKubernetesLabels . }}
@@ -147,7 +148,7 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "agentProvisionScript"}}
 
-runcmd: 
+runcmd:
 - apt-mark hold walinuxagent{{GetKubernetesAgentPreprovisionYaml .}}
 - apt-get update
 - apt-get install -y apt-transport-https ca-certificates nfs-common

--- a/parts/kubernetesagentkubelet.service
+++ b/parts/kubernetesagentkubelet.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/docker run \
   --volume=/sys:/sys:ro \
   --volume=/var/run:/var/run:rw \
   --volume=/var/lib/docker/:/var/lib/docker:rw \
+  --volume=/var/lib/containers/:/var/lib/containers:rw \
   --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
   --volume=/var/log:/var/log:rw \
   --volume=/etc/kubernetes/:/etc/kubernetes:ro \
@@ -44,9 +45,7 @@ ExecStart=/usr/bin/docker run \
         --cloud-config= \
         --azure-container-registry-config= \
         --hairpin-mode=promiscuous-bridge \
-        --network-plugin=${KUBELET_NETWORK_PLUGIN} \
-        --container-runtime=remote \
-        --container-runtime-endpoint=/var/run/crio.sock \
+        --network-plugin=${KUBELET_NETWORK_PLUGIN} $KUBELET_OPTS \
         --v=2
 
 [Install]

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -136,20 +136,6 @@ write_files:
   content: !!binary |
     MASTER_ADDON_KUBE_PROXY_DAEMONSET_B64_GZIP_STR
 
-- path: /etc/kubernetes/addons/azure-storage-classes.yaml
-  permissions: "0644"
-  encoding: gzip
-  owner: "root"
-  content: !!binary |
-    MASTER_ADDON_AZURE_STORAGE_CLASSES_B64_GZIP_STR
-
-- path: /etc/kubernetes/addons/kube-tiller-deployment.yaml
-  permissions: "0644"
-  encoding: gzip
-  owner: "root"
-  content: !!binary |
-    MASTER_ADDON_TILLER_DEPLOYMENT_B64_GZIP_STR
-
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}
 - path: /etc/kubernetes/addons/calico-daemonset.yaml
   permissions: "0644"
@@ -245,7 +231,7 @@ write_files:
         AAD_ISSUER_HOST="sts.chinacloudapi.cn"
     fi
 
-    OIDC_ISSUER_URL="https://$AAD_ISSUER_HOST/$AAD_TENANT_ID/" 
+    OIDC_ISSUER_URL="https://$AAD_ISSUER_HOST/$AAD_TENANT_ID/"
     perl -pi -e "s|--oidc-client-id=\K(?=\")|$OIDC_CLIENT_ID| || s|--oidc-issuer-url=\K(?=\")|$OIDC_ISSUER_URL|" "/etc/kubernetes/manifests/kube-apiserver.yaml"
 {{else}}
     sed -i "/--oidc-client-id\|--oidc-issuer-url\|--oidc-username-claim/d" "/etc/kubernetes/manifests/kube-apiserver.yaml"
@@ -256,7 +242,6 @@ write_files:
     sed -i "s|<kubernetesHyperkubeSpec>|{{WrapAsVariable "kubernetesHyperkubeSpec"}}|g" "/etc/kubernetes/manifests/kube-scheduler.yaml"
     sed -i "s|<kubernetesHyperkubeSpec>|{{WrapAsVariable "kubernetesHyperkubeSpec"}}|g; s|<kubeClusterCidr>|{{WrapAsVariable "kubeClusterCidr"}}|g" "/etc/kubernetes/addons/kube-proxy-daemonset.yaml"
     sed -i "s|<kubernetesKubeDNSSpec>|{{WrapAsVariable "kubernetesKubeDNSSpec"}}|g; s|<kubernetesDNSMasqSpec>|{{WrapAsVariable "kubernetesDNSMasqSpec"}}|g; s|<kubernetesExecHealthzSpec>|{{WrapAsVariable "kubernetesExecHealthzSpec"}}|g" "/etc/kubernetes/addons/kube-dns-deployment.yaml"
-    sed -i "s|<kubernetesTillerSpec>|{{WrapAsVariable "kubernetesTillerSpec"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
     sed -i "s|<kubeDNSServiceIP>|{{WrapAsVariable "kubeDNSServiceIP"}}|g" "/etc/kubernetes/addons/kube-dns-deployment.yaml"
 
 {{if .OrchestratorProfile.KubernetesConfig.EnableRbac }}
@@ -325,7 +310,7 @@ write_files:
     fi
     mount $MOUNTPOINT
 
-runcmd: 
+runcmd:
 - apt-mark hold walinuxagent {{GetKubernetesMasterPreprovisionYaml}}
 - /bin/echo DAEMON_ARGS=--name "{{WrapAsVerbatim "variables('masterVMNames')[copyIndex(variables('masterOffset'))]"}}" --initial-advertise-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --advertise-client-urls "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-client-urls "{{WrapAsVerbatim "concat(variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))], ',http://127.0.0.1:', variables('masterEtcdClientPort'))"}}" --initial-cluster-token "k8s-etcd-cluster" --initial-cluster "{{WrapAsVerbatim "variables('masterEtcdClusterStates')[div(variables('masterCount'), 2)]"}} --data-dir "/var/lib/etcddisk"" --initial-cluster-state "new" | tee -a /etc/default/etcd
 - sudo /bin/chown -R etcd:etcd /var/lib/etcd/default


### PR DESCRIPTION
Fixes the master node which was not having cloud-config work since the tiller files were still in `parts/kubernetesmastercustomdata.yml` and fixes the agents to get clear-containers perfectly running.

