### PR TITLE
Add support for k8s 1.6.11

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -54,6 +54,31 @@ const (
 
 // KubeImages represents Docker images used for Kubernetes components based on Kubernetes version
 var KubeImages = map[api.OrchestratorVersion]map[string]string{
+	api.Kubernetes1611: {
+		"hyperkube":       "hyperkube-amd64:v1.6.11",
+		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
+		"exechealthz":     "exechealthz-amd64:1.2",
+		"addonresizer":    "addon-resizer:1.7",
+		"heapster":        "heapster-amd64:v1.3.0",
+		"dns":             "k8s-dns-kube-dns-amd64:1.14.5",
+		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
+		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.5",
+		"pause":           "pause-amd64:3.0",
+		"tiller":          "tiller:v2.6.2",
+		"windowszip":      "v1.6.11-1intwinnat.zip",
+		"nodestatusfreq":   "1m",
+		"nodegraceperiod":   "5m",
+		"podeviction":   "1m",
+		"routeperiod":   "1m",
+		"backoff": "true",
+		"backoffduration": "5",
+		"backoffexponent": "1.5",
+		"backoffretries": "6",
+		"backoffjitter": "1",
+		"ratelimit": "true",
+		"ratelimitqps": "3",
+		"ratelimitbucket": "10",
+	},
 	api.Kubernetes166: {
 		"hyperkube":    "hyperkube-amd64:v1.6.6",
 		"dashboard":    "kubernetes-dashboard-amd64:v1.6.1",

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -64,7 +64,6 @@ var KubeImages = map[api.OrchestratorVersion]map[string]string{
 		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
 		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 		"pause":           "pause-amd64:3.0",
-		"tiller":          "tiller:v2.6.2",
 		"windowszip":      "v1.6.11-1intwinnat.zip",
 		"nodestatusfreq":   "1m",
 		"nodegraceperiod":   "5m",

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -61,8 +61,10 @@ const (
 	Kubernetes162 OrchestratorVersion = "1.6.2"
 	// Kubernetes166 is the string constant for Kubernetes 1.6.6
 	Kubernetes166 OrchestratorVersion = "1.6.6"
+	// Kubernetes1611 is the string constant for Kubernetes 1.6.11
+	Kubernetes1611 OrchestratorVersion = "1.6.11"
 	// KubernetesLatest is the string constant for latest Kubernetes version
-	KubernetesLatest OrchestratorVersion = Kubernetes166
+	KubernetesLatest OrchestratorVersion = Kubernetes1611
 )
 
 const (

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -92,6 +92,8 @@ const (
 	Kubernetes162 OrchestratorVersion = "1.6.2"
 	// Kubernetes166 is the string constant for Kubernetes 1.6.6
 	Kubernetes166 OrchestratorVersion = "1.6.6"
+	// Kubernetes1611 is the string constant for Kubernetes 1.6.11
+	Kubernetes1611 OrchestratorVersion = "1.6.11"
 	// KubernetesLatest is the string constant for latest Kubernetes version
-	KubernetesLatest OrchestratorVersion = Kubernetes166
+	KubernetesLatest OrchestratorVersion = Kubernetes1611
 )

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -28,6 +28,7 @@ func (o *OrchestratorProfile) Validate() error {
 
 	case Kubernetes:
 		switch o.OrchestratorVersion {
+		case Kubernetes1611:
 		case Kubernetes166:
 		case Kubernetes162:
 		case Kubernetes160:


### PR DESCRIPTION
**What this PR does / why we need it**: Add support for k8s 1.6.11, which contains a security fix on k8s 1.6.6, including  CVE-2016-9841, CVE-2016-9843, CVE-2017-2616 [SIC], and CVE-2017-6512.

**Which issue this PR fixes**: # CVE-2016-9841, CVE-2016-9843, CVE-2017-2616 [SIC], and CVE-2017-6512.

