### PR TITLE
skip create initial role binding due to bulit-in RBAC support.

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -700,8 +700,6 @@ if [[ ! -z "${APISERVER_PRIVATE_KEY}" ]]; then
     ensureEtcdDataDir
     ensureEtcd
     ensureApiserver
-
-    /usr/local/bin/kubectl create clusterrolebinding superuser --clusterrole=cluster-admin --user=client
 fi
 
 if [[ $OS == $UBUNTU_OS_NAME ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We do not need to create initial role binding anymore with built-int RBAC support.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
